### PR TITLE
Functional update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.json
 tmp/
 *.log
+fred/inference/model_files.bz2
+fred/inference/model_files/*.pth

--- a/fred/inference/predict.py
+++ b/fred/inference/predict.py
@@ -47,18 +47,19 @@ def predict(image_file):
     model = NNet()
     model.load_state_dict(torch.load(model_path, map_location='cpu'))
     model.eval()
+    
+    with torch.no_grad():
+        pilim = Image.open(image_file).convert('L').convert('RGB')
+        pilim = preprocess_pilim(pilim)
+        input_array = prepare_for_input(pilim, flip_lr=False)
 
-    pilim = Image.open(image_file).convert('L').convert('RGB')
-    pilim = preprocess_pilim(pilim)
-    input_array = prepare_for_input(pilim, flip_lr=False)
+        lr_input_array = prepare_for_input(pilim, flip_lr=True)
+        try:
+            out_array = get_output(model(get_tensor(input_array)))
+        except:
+            exit(2)
 
-    lr_input_array = prepare_for_input(pilim, flip_lr=True)
-    try:
-        out_array = get_output(model(get_tensor(input_array)))
-    except:
-        exit(2)
-
-    lr_out_array = np.fliplr(get_output(model(get_tensor(lr_input_array))))
+        lr_out_array = np.fliplr(get_output(model(get_tensor(lr_input_array))))
 
     out_array = (out_array + lr_out_array) / 2
     out_array = threshold_output(out_array, 0.5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy==1.17.1
 Pillow==6.1.0
 beautifulsoup4==4.8.0
 pyppeteer==0.0.25
+websockets==6.0


### PR DESCRIPTION
Update gitignore and requirements.txt. The requirements.txt forces websocket 6.0 to overcome a known network issue that makes pypupeteer to fail (neither websocket 7 or 8.1 work).

Add the no_grad() in the predict() function to stabilize RAM consumption and to speed up the inference a bit.